### PR TITLE
Fix buttons in #page-action-button not being clickable

### DIFF
--- a/pineapple-fried/wazz-tweaks/Modules/community-changes/url-loading-animation.css
+++ b/pineapple-fried/wazz-tweaks/Modules/community-changes/url-loading-animation.css
@@ -11,6 +11,7 @@
       animation-play-state: paused;
       opacity: 0;
       transition: opacity 0.25s;
+      pointer-events: none;
     }
   }
   


### PR DESCRIPTION
Closes #1 
This fixes buttons under the element `<hbox id="page-action-buttons" ...` that were previously unclickable (namely bookmark button) and would instead open the url bar.